### PR TITLE
Orchard branding

### DIFF
--- a/Orchard_Branding/Orchard_Branding.munki.recipe
+++ b/Orchard_Branding/Orchard_Branding.munki.recipe
@@ -35,11 +35,61 @@
         <key>category</key>
         <string>System Software</string>
         <key>description</key>
-        <string>Deploys Orchard branding files (desktops, user pictures, login icons) to /Library/Orchard.</string> 
+        <string>Deploys Orchard branding files (desktops, user pictures, login icons) to /Library/Orchard.</string>
         <key>developer</key>
         <string>Oxford University</string>
         <key>display_name</key>
         <string>Orchard Branding</string>
+        <key>postuninstall_script</key>
+        <string>#!/bin/bash
+#
+# Undoes the changes made by script payload/usr/local/boot-once/setDefaultDesktopPicture.sh
+# For inclusion in pkginfo postuninstall_script key of Orchard_Branding package.
+#
+# Copyright (C) 2017 Oxford University
+#    Christopher Beard christopher.beard(at)it.ox.ac.uk>
+#
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of the GNU
+# General Public License version 3 as published by
+# the Free Software Foundation.
+#
+################################################################################!/bin/bash
+
+OS_DESKTOPS='/Library/Desktop Pictures'
+OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
+
+function restoreDefaultDesktop {
+  local OS_DEFAULT=$1
+
+  # Stop if the default file is not a symlink
+  [ ! -h "${OS_DESKTOPS}/${OS_DEFAULT}" ] &amp;&amp; { echo "ERROR: Default desktop file '${OS_DESKTOPS}/${OS_DEFAULT}' is not a symlink, exiting."; exit 1; }
+
+  echo "Removing symlink '${OS_DESKTOPS}/${OS_DEFAULT}' to '${ORCHARD_DESKTOP}'"
+  rm "${OS_DESKTOPS}/${OS_DEFAULT}"
+
+  echo "Renaming 'Default - ${OS_DEFAULT}' back to ${OS_DESKTOPS}/${OS_DEFAULT}"
+  mv "${OS_DESKTOPS}/Default - ${OS_DEFAULT}" "${OS_DESKTOPS}/${OS_DEFAULT}"
+}
+
+case $OS_VERSION in
+  10)
+    echo "OS X 10.10 detected."
+    restoreDefaultDesktop 'Yosemite.jpg'
+    ;;
+  11)
+    echo "OS X 10.11 detected."
+    restoreDefaultDesktop 'El Capitan.jpg'
+    ;;
+  12)
+    echo "macOS 10.12 detected."
+    restoreDefaultDesktop 'Sierra.jpg'
+    ;;
+  *)
+    echo "ERROR: Unsupported macOS version."
+    exit 1
+    ;;
+esac</string>
         <key>name</key>
         <string>%NAME%</string>
         <key>unattended_install</key>
@@ -49,7 +99,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>uk.ac.ox.orchard.pkg.Orchard_Branding</string> 
+    <string>uk.ac.ox.orchard.pkg.Orchard_Branding</string>
     <key>Process</key>
     <array>
       <!-- Import to munki repo -->

--- a/Orchard_Branding/payload/usr/local/outset/boot-once/setDefaultDesktopPicture.sh
+++ b/Orchard_Branding/payload/usr/local/outset/boot-once/setDefaultDesktopPicture.sh
@@ -14,6 +14,7 @@
 ###############################################################################
 OS_DESKTOPS='/Library/Desktop Pictures'
 ORCHARD_DESKTOP='/Library/Orchard/Artwork/Desktop_Pictures/Oxford-Crest-Centre.jpg'
+OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
 
 function applyOrchardDesktop {
   local OS_DEFAULT=$1
@@ -28,8 +29,6 @@ function applyOrchardDesktop {
   ln -s "${ORCHARD_DESKTOP}" "${OS_DESKTOPS}/${OS_DEFAULT}"
 }
 
-OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
-
 case $OS_VERSION in
   10)
     echo "OS X 10.10 detected."
@@ -38,6 +37,10 @@ case $OS_VERSION in
   11)
     echo "OS X 10.11 detected."
     applyOrchardDesktop 'El Capitan.jpg'
+    ;;
+  12)
+    echo "macOS 10.12 detected."
+    applyOrchardDesktop 'Sierra.jpg'  
     ;;
   *)
     echo "ERROR: Unsupported macOS version."

--- a/Orchard_Branding/payload/usr/local/outset/boot-once/setDefaultDesktopPicture.sh
+++ b/Orchard_Branding/payload/usr/local/outset/boot-once/setDefaultDesktopPicture.sh
@@ -22,10 +22,10 @@ function applyOrchardDesktop {
   # Stop if the default file is already a symlink
   [ -h "${OS_DESKTOPS}/${OS_DEFAULT}" ] && { echo "Default desktop file '${OS_DESKTOPS}/${OS_DEFAULT}' is already a symlink, exiting."; exit 1; }
 
-  echo "Renaming ${OS_DESKTOPS}/${OS_DEFAULT} to 'Default - ${OS_DEFAULT}'"
+  echo "Renaming '${OS_DESKTOPS}/${OS_DEFAULT}' to 'Default - ${OS_DEFAULT}'"
   mv "${OS_DESKTOPS}/${OS_DEFAULT}" "${OS_DESKTOPS}/Default - ${OS_DEFAULT}"
 
-  echo "Creating symlink ${OS_DESKTOPS}/${OS_DEFAULT} to ${ORCHARD_DESKTOP}"
+  echo "Creating symlink '${OS_DESKTOPS}/${OS_DEFAULT}' to '${ORCHARD_DESKTOP}'"
   ln -s "${ORCHARD_DESKTOP}" "${OS_DESKTOPS}/${OS_DEFAULT}"
 }
 

--- a/Orchard_Branding/scripts/resetDefaultDesktop-postinstall.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop-postinstall.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Undoes the changes made by script payload/usr/local/boot-once/setDefaultDesktopPicture.sh
+# For inclusion in post-install of Orchard_Branding package.
+#
+# Copyright (C) 2017 Oxford University
+#    Christopher Beard christopher.beard(at)it.ox.ac.uk>
+#
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of the GNU
+# General Public License version 3 as published by
+# the Free Software Foundation.
+#
+################################################################################!/bin/bash
+
+OS_DESKTOPS='/Library/Desktop Pictures'
+OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
+
+function restoreDefaultDesktop {
+  local OS_DEFAULT=$1  
+
+  # Stop if the default file is not a symlink
+  [ ! -h "${OS_DESKTOPS}/${OS_DEFAULT}" ] &amp;&amp; { echo "ERROR: Default desktop file '${OS_DESKTOPS}/${OS_DEFAULT}' is not a symlink, exiting."; exit 1; }
+
+  echo "Removing symlink '${OS_DESKTOPS}/${OS_DEFAULT}' to '${ORCHARD_DESKTOP}'"
+  rm "${OS_DESKTOPS}/${OS_DEFAULT}"
+
+  echo "Renaming 'Default - ${OS_DEFAULT}' back to ${OS_DESKTOPS}/${OS_DEFAULT}" 
+  mv "${OS_DESKTOPS}/Default - ${OS_DEFAULT}" "${OS_DESKTOPS}/${OS_DEFAULT}"
+}
+
+case $OS_VERSION in
+  10)
+    echo "OS X 10.10 detected."
+    restoreDefaultDesktop 'Yosemite.jpg'
+    ;;
+  11)
+    echo "OS X 10.11 detected."
+    restoreDefaultDesktop 'El Capitan.jpg'
+    ;; 
+  12)
+    echo "macOS 10.12 detected." 
+    restoreDefaultDesktop 'Sierra.jpg'
+    ;;
+  *)
+    echo "ERROR: Unsupported macOS version."
+    exit 1
+    ;;
+esac

--- a/Orchard_Branding/scripts/resetDefaultDesktop-postuninstall_script.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop-postuninstall_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Undoes the changes made by script payload/usr/local/boot-once/setDefaultDesktopPicture.sh
-# For inclusion in post-install of Orchard_Branding package.
+# For inclusion in pkginfo postuninstall_script key of Orchard_Branding package.
 #
 # Copyright (C) 2017 Oxford University
 #    Christopher Beard christopher.beard(at)it.ox.ac.uk>

--- a/Orchard_Branding/scripts/resetDefaultDesktop.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Undoes the changes made by script payload/usr/local/boot-once/setDefaultDesktopPicture.sh
-# For inclusion in post-install of Orchard_Branding package.
+# For inclusion in pkginfo postuninstall_script key of Orchard_Branding package.
 #
 # Copyright (C) 2017 Oxford University
 #    Christopher Beard christopher.beard(at)it.ox.ac.uk>

--- a/Orchard_Branding/scripts/resetDefaultDesktop.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop.sh
@@ -15,6 +15,7 @@
 
 OS_DESKTOPS='/Library/Desktop Pictures'
 ORCHARD_DESKTOP='/Library/Orchard/Artwork/Desktop_Pictures/Oxford-Crest-Centre.jpg'
+OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
 
 function restoreDefaultDesktop {
   local OS_DEFAULT=$1  
@@ -22,7 +23,7 @@ function restoreDefaultDesktop {
   # Stop if the dfault file is not a symlink
   [ ! -h "${OS_DESKTOPS}/${OS_DEFAULT}" ] && { echo "ERROR: Default desktop file '${OS_DESKTOPS}/${OS_DEFAULT}' is not a symlink, exiting."; exit 1; }
 
-  echo "Removing symlink ${OS_DESKTOPS}/${OS_DEFAULT} to ${ORCHARD_DESKTOP}"
+  echo "Removing symlink '${OS_DESKTOPS}/${OS_DEFAULT}' to '${ORCHARD_DESKTOP}'"
   rm "${OS_DESKTOPS}/${OS_DEFAULT}"
 
   echo "Renaming 'Default - ${OS_DEFAULT}' back to ${OS_DESKTOPS}/${OS_DEFAULT}" 

--- a/Orchard_Branding/scripts/resetDefaultDesktop.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop.sh
@@ -1,10 +1,49 @@
 #!/bin/bash
+#
+# Undoes the changes made by script payload/usr/local/boot-once/setDefaultDesktopPicture.sh
+# For inclusion in post-install of Orchard_Branding package.
+#
+# Copyright (C) 2017 Oxford University
+#    Christopher Beard christopher.beard(at)it.ox.ac.uk>
+#
+# This program is free software; you can redistribute
+# it and/or modify it under the terms of the GNU
+# General Public License version 3 as published by
+# the Free Software Foundation.
+#
+################################################################################!/bin/bash
 
 OS_DESKTOPS='/Library/Desktop Pictures'
-DEFAULT_DESKTOP='El Capitan.jpg'
 ORCHARD_DESKTOP='/Library/Orchard/Artwork/Desktop_Pictures/Oxford-Crest-Centre.jpg'
 
-# Remove link
-rm "${OS_DESKTOPS}/${DEFAULT_DESKTOP}"
-# Rename jpg to original
-mv "${OS_DESKTOPS}/Default - ${DEFAULT_DESKTOP}" "${OS_DESKTOPS}/${DEFAULT_DESKTOP}"
+function restoreDefaultDesktop {
+  local OS_DEFAULT=$1  
+
+  # Stop if the dfault file is not a symlink
+  [ ! -h "${OS_DESKTOPS}/${OS_DEFAULT}" ] && { echo "ERROR: Default desktop file '${OS_DESKTOPS}/${OS_DEFAULT}' is not a symlink, exiting."; exit 1; }
+
+  echo "Removing symlink ${OS_DESKTOPS}/${OS_DEFAULT} to ${ORCHARD_DESKTOP}"
+  rm "${OS_DESKTOPS}/${OS_DEFAULT}"
+
+  echo "Renaming 'Default - ${OS_DEFAULT}' back to ${OS_DESKTOPS}/${OS_DEFAULT}" 
+  mv "${OS_DESKTOPS}/Default - ${OS_DEFAULT}" "${OS_DESKTOPS}/${OS_DEFAULT}"
+}
+
+case $OS_VERSION in
+  10)
+    echo "OS X 10.10 detected."
+    restoreDefaultDesktop 'Yosemite.jpg'
+    ;;
+  11)
+    echo "OS X 10.11 detected."
+    restoreDefaultDesktop 'El Capitan.jpg'
+    ;; 
+  12)
+    echo "macOS 10.12 detected." 
+    restoreDefaultDesktop 'Sierra.jpg'
+    ;;
+  *)
+    echo "ERROR: Unsupported macOS version."
+    exit 1
+    ;;
+esac

--- a/Orchard_Branding/scripts/resetDefaultDesktop.sh
+++ b/Orchard_Branding/scripts/resetDefaultDesktop.sh
@@ -14,7 +14,6 @@
 ################################################################################!/bin/bash
 
 OS_DESKTOPS='/Library/Desktop Pictures'
-ORCHARD_DESKTOP='/Library/Orchard/Artwork/Desktop_Pictures/Oxford-Crest-Centre.jpg'
 OS_VERSION=$(sw_vers -productVersion | /usr/bin/awk -F'.' '{ print $2 }') || { echo "Could not extract OS version."; exit 1; }
 
 function restoreDefaultDesktop {


### PR DESCRIPTION
Extended scripts to support macOS 10.12 and added reset script as a postuninstall_script for the package in munki.